### PR TITLE
Update README.md to specify the version of msal android

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ dependencies:
 Please ensure you are using Kotlin version 1.4.31 or later. To set this, goto your app's android folder, open the build.gradle file, and under buildscript:ext.kotlin_version change the version to 1.4.31 or later.
 
 This section is mostly copied and modified from [the official android MSAL library github repository](https://github.com/AzureAD/microsoft-authentication-library-for-android). Visit the repository for more details and information on how to use it with authentication brokers.
+For msal_flutter version 2.0.* make sure to install version 2.2.3 of the msal android library.
 
 1. Ensure your AndroidManifest.xml includes internet permissions
 


### PR DESCRIPTION
Hi, sorry if this is unnecessary, but my team and I were ripping our hair out for days since we could not get the silent login to work. Turns out the documentation in https://github.com/AzureAD/microsoft-authentication-library-for-android says to use version 3.0+ of the msal android library, but that throws an error when trying to silently obtain the user's token. Downgrading to version 2.2.3 fixes this.